### PR TITLE
Fix blank screen issue by adding an intermediary screen rotation

### DIFF
--- a/inspironRotateScreen
+++ b/inspironRotateScreen
@@ -9,7 +9,15 @@ matrix[3]="0 -1 1 1 0 0 0 0 1"
 matrix[4]="-1 0 1 0 -1 1 0 0 1"
 
 rotatescreen(){
-	xrandr --screen 0 -o $1
+
+	# Use an intermediary "screen rotate left" if going to "normal" or "inverted"
+	if [ "$1" == "normal" -o "$1" == "inverted" ]
+	then
+		xrandr --screen 0 -o "left" && xrandr --screen 0 -o $1
+	else
+		xrandr --screen 0 -o $1
+	fi
+
 	if [ $1 == "normal" ]
 	then
 		for index in 1 2

--- a/inspironRotateService
+++ b/inspironRotateService
@@ -11,9 +11,18 @@ do
 done
 
 #echo $IIODEVICE
+screenRotationOld="normal"
 
 while true
 do
-	inspironReadSensor $IIODEVICE | xargs inspironRotateScreen
+	screenRotation=`inspironReadSensor $IIODEVICE`
+
+	# Only run inspironRotateScreen when the orientation has changed
+	if [ "$screenRotation" != "$screenRotationOld" ]
+	then
+		screenRotationOld=$screenRotation
+		inspironRotateScreen "$screenRotation"
+	fi
+
 	sleep 5
 done


### PR DESCRIPTION
This is a fix for the issue I raised in #1 . All I did was add an intermediary `xrandr` command to rotate the screen left first before going directly from normal rotation to inverted and vice versa. I also changed the code so it only executes `inspironRotateScreen` when the program notices the rotation was actually changed.
